### PR TITLE
Detect IE on desktop

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,14 @@ function info(){
       os: os
     };
   }
+  if (match[1] === 'MSIE') {
+      tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
+      return {
+          name: 'IEMobile',
+          version: (tem[1]||''),
+          os: os
+      };
+  }
   if (match[1] === 'Chrome') {
     tem = ua.match(/\bOPR\/(\d+)/);
     if (tem !== null) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function info(){
   var tem;
   var os;
 
-  var match = ua.match(/(opera|chrome|safari|firefox|msie|edge|trident(?=\/))\/?\s*(\d+)/i) || [];
+  var match = ua.match(/(opera|chrome|safari|firefox|edge|trident(?=\/))\/?\s*(\d+)/i) || [];
 
   if (ua.indexOf('Win') !== -1) {
     os = 'Windows';
@@ -28,6 +28,9 @@ function info(){
   if (/iPad|iPhone|iPod/.test(ua)) {
     os = 'iOS';
   }
+  if (ua.indexOf('Windows Phone') !== -1) {
+      os = 'Windows Phone';
+  }
 
   if (/trident/i.test(match[1])) {
     tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
@@ -36,14 +39,6 @@ function info(){
       version: (tem[1]||''),
       os: os
     };
-  }
-  if (match[1] === 'MSIE') {
-      tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
-      return {
-          name: 'IEMobile',
-          version: (tem[1]||''),
-          os: os
-      };
   }
   if (match[1] === 'Chrome') {
     tem = ua.match(/\bOPR\/(\d+)/);

--- a/test/index.js
+++ b/test/index.js
@@ -40,4 +40,13 @@ describe('browser-info', function() {
      should(info().name).equal('Edge');
      done();
   });
+
+  it('should detect IE mobile', function(done) {
+      GLOBAL.navigator = {
+          userAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)'
+      };
+
+      should(info().name).equal('IEMobile');
+      done();
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,17 @@ describe('browser-info', function() {
           userAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)'
       };
 
-      should(info().name).equal('IEMobile');
+      should(info().os).equal('Windows Phone');
+      should(info().name).equal('IE');
+      done();
+  });
+
+  it('should detect IE', function(done) {
+      GLOBAL.navigator = {
+          userAgent: 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
+      };
+
+      should(info().name).equal('IE');
       done();
   });
 });


### PR DESCRIPTION
I noticed that it returns `IEMobile` for all IE versions, I moved the mobile/desktop detection to the `os` field instead, and the `name` field will always return `IE`. 