### PR TITLE
fix IE version split error

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function info(){
     tem = /\brv[ :]+(\S+[0-9])/g.exec(ua) || [];
     return {
       name: 'IE',
-      version: tem[1].split('.')[0],
+      version: tem[1] && tem[1].split('.')[0],
       fullVersion: tem[1],
       os: os
     };


### PR DESCRIPTION
I found that the following UserAgent is causing `undefined.split()` to be called.

`Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E)`

![](https://gyazo.com/0049341af217b4fa2c3de7c72774809b/raw)

## fixed
![](https://gyazo.com/53eb3629b4b6ab7a88cba71d9688f582/raw)
