### PR TITLE
Added support for new Microsoft Edge

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function info(userAgent){
       };
     }
 
-    tem = ua.match(/\bEdge\/(\S+)/);
+    tem = ua.match(/\bEdg\/(\S+)/) || ua.match(/\bEdge\/(\S+)/);
     if (tem !== null) {
       return {
         name: 'Edge',


### PR DESCRIPTION
Resolved the Issue #21 

### Issue:
The new Microsoft Edge is detected as Chrome.

### Fix:
Microsoft changed the name from Edge to Edg as shown in the UserAgent field of the request:

`User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Safari/537.36 Edg/80.0.361.109`

So added another match condition for the string **"Edg"** as well.

### Validation:
Changes validated locally.

@stevelacy Can you please check, verify, merge and publish the changes asap, as we are using this library and getting wrong browser information, which is a serious issue in our case. Thank you.  